### PR TITLE
Fix faulty imports

### DIFF
--- a/queries/ruby/scopeTypes.scm
+++ b/queries/ruby/scopeTypes.scm
@@ -1,0 +1,15 @@
+(comment) @comment
+(if) @ifStatement
+(call) @functionCall
+(method) @namedFunction
+(hash) @map
+
+[
+  (array)
+  (string_array)
+  (symbol_array)
+] @list
+
+(regex) @regularExpression
+
+(class) @class

--- a/src/core/commandRunner/CommandRunner.ts
+++ b/src/core/commandRunner/CommandRunner.ts
@@ -104,6 +104,7 @@ export default class CommandRunner {
         thatMark: this.thatMark.exists() ? this.thatMark.get() : [],
         sourceMark: this.sourceMark.exists() ? this.sourceMark.get() : [],
         getNodeAtLocation: this.graph.getNodeAtLocation,
+        getTree: this.graph.getTree,
       };
 
       if (this.graph.testCaseRecorder.isActive()) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,7 @@ import CommandRunner from "./core/commandRunner/CommandRunner";
  * - Creates an entrypoint for running commands {@link CommandRunner}.
  */
 export async function activate(context: vscode.ExtensionContext) {
-  const { getNodeAtLocation } = await getParseTreeApi();
+  const { getNodeAtLocation, getTree } = await getParseTreeApi();
   const commandServerApi = await getCommandServerApi();
 
   const graph = makeGraph({
@@ -24,6 +24,7 @@ export async function activate(context: vscode.ExtensionContext) {
     extensionContext: () => context,
     commandServerApi: () => commandServerApi,
     getNodeAtLocation: () => getNodeAtLocation,
+    getTree: () => getTree,
   } as FactoryMap<Graph>);
   graph.debug.init();
   graph.snippets.init();

--- a/src/languages/getNodeMatcher.ts
+++ b/src/languages/getNodeMatcher.ts
@@ -1,7 +1,7 @@
 import { intersection } from "lodash";
 import { SyntaxNode, Tree } from "web-tree-sitter";
 import { UnsupportedLanguageError } from "../errors";
-import { SimpleScopeTypeType } from "../typings/target.types";
+import { SimpleScopeTypeType } from "../typings/targetDescriptor.types";
 import {
   NodeMatcher,
   NodeMatcherValue,

--- a/src/languages/html.ts
+++ b/src/languages/html.ts
@@ -1,5 +1,5 @@
 import { SyntaxNode, Tree } from "web-tree-sitter";
-import { SimpleScopeTypeType } from "../typings/target.types";
+import { SimpleScopeTypeType } from "../typings/targetDescriptor.types";
 import { NodeMatcherAlternative, SelectionWithEditor } from "../typings/Types";
 import {
   createPatternMatchers,

--- a/src/languages/html.ts
+++ b/src/languages/html.ts
@@ -1,11 +1,11 @@
+import { SyntaxNode, Tree } from "web-tree-sitter";
+import { SimpleScopeTypeType } from "../typings/target.types";
+import { NodeMatcherAlternative, SelectionWithEditor } from "../typings/Types";
 import {
   createPatternMatchers,
   leadingMatcher,
   patternMatcher,
 } from "../util/nodeMatchers";
-import { NodeMatcherAlternative, SelectionWithEditor } from "../typings/Types";
-import { SimpleScopeTypeType } from "../typings/targetDescriptor.types";
-import { SyntaxNode } from "web-tree-sitter";
 import { getNodeRange } from "../util/nodeSelectors";
 
 const attribute = "*?.attribute!";
@@ -13,7 +13,7 @@ const attribute = "*?.attribute!";
 const getStartTag = patternMatcher(`*?.start_tag!`);
 const getEndTag = patternMatcher(`*?.end_tag!`);
 
-const getTags = (selection: SelectionWithEditor, node: SyntaxNode) => {
+const getTags = (selection: SelectionWithEditor, node: SyntaxNode | Tree) => {
   const startTag = getStartTag(selection, node);
   const endTag = getEndTag(selection, node);
   return startTag != null && endTag != null ? startTag.concat(endTag) : null;

--- a/src/languages/queryBasedSpecification.ts
+++ b/src/languages/queryBasedSpecification.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import {
   SimpleScopeTypeType,
   simpleScopeTypeTypes,
-} from "../typings/target.types";
+} from "../typings/targetDescriptor.types";
 import { NodeMatcherAlternative } from "../typings/Types";
 import { createPatternMatchers } from "../util/nodeMatchers";
 import { defaultMatcher } from "../util/queryNodeMatchers";

--- a/src/languages/queryBasedSpecification.ts
+++ b/src/languages/queryBasedSpecification.ts
@@ -1,0 +1,46 @@
+import * as fs from "fs";
+import * as path from "path";
+import {
+  SimpleScopeTypeType,
+  simpleScopeTypeTypes,
+} from "../typings/target.types";
+import { NodeMatcherAlternative } from "../typings/Types";
+import { createPatternMatchers } from "../util/nodeMatchers";
+import { defaultMatcher } from "../util/queryNodeMatchers";
+
+function getMatchers(
+  queries: string
+): Partial<Record<SimpleScopeTypeType, NodeMatcherAlternative>> {
+  const matchers: Partial<Record<SimpleScopeTypeType, NodeMatcherAlternative>> =
+    {};
+  for (const scopeTypeType of simpleScopeTypeTypes) {
+    generateMatcher(queries, scopeTypeType, matchers);
+  }
+  return matchers;
+}
+
+function generateMatcher(
+  queries: string,
+  scopeTypeType: SimpleScopeTypeType,
+  matchers: Partial<Record<SimpleScopeTypeType, NodeMatcherAlternative>>
+) {
+  if (queries.match(`@${scopeTypeType}[^a-zA-Z]`)) {
+    const isIterationScopePresent = !!queries.match(
+      `@${scopeTypeType}.iterationScope[^a-zA-Z]`
+    );
+    matchers[scopeTypeType as SimpleScopeTypeType] = defaultMatcher(
+      scopeTypeType,
+      isIterationScopePresent,
+      queries
+    );
+  }
+}
+
+export default function (languageName: string) {
+  const queryPath = fs.readFileSync(
+    path.join(__dirname, `../queries/${languageName}/scopeTypes.scm`),
+    "utf-8"
+  );
+
+  return createPatternMatchers(getMatchers(queryPath));
+}

--- a/src/languages/ruby.ts
+++ b/src/languages/ruby.ts
@@ -151,8 +151,6 @@ function blockFinder(node: SyntaxNode) {
 const nodeMatchers: Partial<
   Record<SimpleScopeTypeType, NodeMatcherAlternative>
 > = {
-  map: mapTypes,
-  list: listTypes,
   statement: cascadingMatcher(
     patternMatcher(...STATEMENT_TYPES),
     ancestorChainNodeMatcher(
@@ -164,16 +162,11 @@ const nodeMatchers: Partial<
     )
   ),
   string: "string",
-  ifStatement: "if",
-  functionCall: "call",
-  comment: "comment",
-  namedFunction: "method",
   functionName: "method[name]",
   anonymousFunction: cascadingMatcher(
     patternMatcher("lambda", "do_block"),
     matcher(blockFinder)
   ),
-  regularExpression: "regex",
   condition: conditionMatcher("*[condition]"),
   argumentOrParameter: argumentMatcher(
     "lambda_parameters",
@@ -181,9 +174,8 @@ const nodeMatchers: Partial<
     "block_parameters",
     "argument_list"
   ),
-  class: "class",
-  className: "class[name]",
   collectionKey: trailingMatcher(["pair[key]"], [":"]),
+  className: "class[name]",
   name: [
     "assignment[left]",
     "operator_assignment[left]",

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -1,4 +1,4 @@
-import { SyntaxNode } from "web-tree-sitter";
+import { SyntaxNode, Tree } from "web-tree-sitter";
 import {
   matcher,
   cascadingMatcher,
@@ -66,7 +66,11 @@ const STATEMENT_TYPES = [
 const getStartTag = patternMatcher("jsx_element.jsx_opening_element!");
 const getEndTag = patternMatcher("jsx_element.jsx_closing_element!");
 
-const getTags = (selection: SelectionWithEditor, node: SyntaxNode) => {
+const getTags = (
+  selection: SelectionWithEditor,
+  treeSitterHook: SyntaxNode | Tree
+) => {
+  const node = treeSitterHook as SyntaxNode;
   const startTag = getStartTag(selection, node);
   const endTag = getEndTag(selection, node);
   return startTag != null && endTag != null ? startTag.concat(endTag) : null;
@@ -74,7 +78,11 @@ const getTags = (selection: SelectionWithEditor, node: SyntaxNode) => {
 
 function typeMatcher(): NodeMatcher {
   const delimiterSelector = selectWithLeadingDelimiter(":");
-  return function (selection: SelectionWithEditor, node: SyntaxNode) {
+  return function (
+    selection: SelectionWithEditor,
+    treeSitterHook: SyntaxNode | Tree
+  ) {
+    const node = treeSitterHook as SyntaxNode;
     if (
       node.parent?.type === "new_expression" &&
       node.type !== "new" &&

--- a/src/processTargets/modifiers/scopeTypeStages/ContainingSyntaxScopeStage.ts
+++ b/src/processTargets/modifiers/scopeTypeStages/ContainingSyntaxScopeStage.ts
@@ -9,7 +9,10 @@ import {
   ContainingScopeModifier,
   EveryScopeModifier,
   SimpleScopeType,
-  SimpleScopeTypeType, Target
+  SimpleScopeTypeType
+} from "../../../typings/targetDescriptor.types";
+import {
+  Target
 } from "../../../typings/target.types";
 import {
   NodeMatcher,
@@ -20,7 +23,6 @@ import {
 import { selectionWithEditorFromRange } from "../../../util/selectionUtils";
 import { ModifierStage } from "../../PipelineStages.types";
 import ScopeTypeTarget from "../../targets/ScopeTypeTarget";
-} from "../../../typings/targetDescriptor.types";
 
 export interface SimpleContainingScopeModifier extends ContainingScopeModifier {
   scopeType: SimpleScopeType;

--- a/src/test/suite/fixtures/recorded/languages/typescript/changeCall.yml
+++ b/src/test/suite/fixtures/recorded/languages/typescript/changeCall.yml
@@ -1,0 +1,23 @@
+languageId: ruby
+command:
+  version: 1
+  spokenForm: change call
+  action: clearAndSetSelection
+  targets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: functionCall, includeSiblings: false}
+initialState:
+  documentContents: hello()world()
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+  marks: {}
+finalState:
+  documentContents: hello()
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+  thatMark:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: containingScope, scopeType: functionCall, includeSiblings: false}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList.yml
+++ b/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList.yml
@@ -1,0 +1,27 @@
+languageId: ruby
+command:
+  version: 1
+  spokenForm: change list
+  action: clearAndSetSelection
+  targets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: list, includeSiblings: false}
+initialState:
+  documentContents: |
+    ["hello"]
+    #comment    
+    ["world"]
+  selections:
+    - anchor: {line: 0, character: 5}
+      active: {line: 2, character: 6}
+  marks: {}
+finalState:
+  documentContents: |+
+
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: containingScope, scopeType: list, includeSiblings: false}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList10.yml
+++ b/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList10.yml
@@ -1,0 +1,23 @@
+languageId: ruby
+command:
+  version: 1
+  spokenForm: change list
+  action: clearAndSetSelection
+  targets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: list, includeSiblings: false}
+initialState:
+  documentContents: "[1, 2, 3, [4, 5, 6, [7, 8, 9]]]"
+  selections:
+    - anchor: {line: 0, character: 18}
+      active: {line: 0, character: 18}
+  marks: {}
+finalState:
+  documentContents: "[1, 2, 3, ]"
+  selections:
+    - anchor: {line: 0, character: 10}
+      active: {line: 0, character: 10}
+  thatMark:
+    - anchor: {line: 0, character: 10}
+      active: {line: 0, character: 10}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: containingScope, scopeType: list, includeSiblings: false}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList11.yml
+++ b/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList11.yml
@@ -1,0 +1,23 @@
+languageId: ruby
+command:
+  version: 1
+  spokenForm: change list
+  action: clearAndSetSelection
+  targets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: list, includeSiblings: false}
+initialState:
+  documentContents: "[1, 2, 3, [4, 5, 6, [7, 8, 9]]]"
+  selections:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+  marks: {}
+finalState:
+  documentContents: ""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: containingScope, scopeType: list, includeSiblings: false}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList12.yml
+++ b/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList12.yml
@@ -1,0 +1,23 @@
+languageId: ruby
+command:
+  version: 1
+  spokenForm: change list
+  action: clearAndSetSelection
+  targets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: list, includeSiblings: false}
+initialState:
+  documentContents: "[1, 2, 3, [4, 5, 6, [7, 8, 9]]]"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: ""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: containingScope, scopeType: list, includeSiblings: false}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList13.yml
+++ b/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList13.yml
@@ -1,0 +1,26 @@
+languageId: ruby
+command:
+  version: 1
+  spokenForm: change list
+  action: clearAndSetSelection
+  targets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: list, includeSiblings: false}
+initialState:
+  documentContents: |-
+    [1, 2, 3, [4, 5, 6, [7, 8, 9]]]
+
+    [["a"], ["b", "c", ["d", "e"]], "f"]
+  selections:
+    - anchor: {line: 0, character: 24}
+      active: {line: 2, character: 4}
+  marks: {}
+finalState:
+  documentContents: "[1, 2, 3, [4, 5, 6, , [\"b\", \"c\", [\"d\", \"e\"]], \"f\"]"
+  selections:
+    - anchor: {line: 0, character: 20}
+      active: {line: 0, character: 20}
+  thatMark:
+    - anchor: {line: 0, character: 20}
+      active: {line: 0, character: 20}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: containingScope, scopeType: list, includeSiblings: false}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList14.yml
+++ b/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList14.yml
@@ -1,0 +1,26 @@
+languageId: ruby
+command:
+  version: 1
+  spokenForm: change list
+  action: clearAndSetSelection
+  targets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: list, includeSiblings: false}
+initialState:
+  documentContents: |-
+    [1, 2, 3, [4, 5, 6, [7, 8, 9]]]
+
+    [["a"], ["b", "c", ["d", "e"]], "f"]
+  selections:
+    - anchor: {line: 0, character: 14}
+      active: {line: 2, character: 14}
+  marks: {}
+finalState:
+  documentContents: "[1, 2, 3, , \"f\"]"
+  selections:
+    - anchor: {line: 0, character: 10}
+      active: {line: 0, character: 10}
+  thatMark:
+    - anchor: {line: 0, character: 10}
+      active: {line: 0, character: 10}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: containingScope, scopeType: list, includeSiblings: false}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList2.yml
+++ b/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList2.yml
@@ -1,0 +1,23 @@
+languageId: ruby
+command:
+  version: 1
+  spokenForm: change list
+  action: clearAndSetSelection
+  targets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: list, includeSiblings: false}
+initialState:
+  documentContents: "[\"hello\"]"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: ""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: containingScope, scopeType: list, includeSiblings: false}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList3.yml
+++ b/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList3.yml
@@ -1,0 +1,23 @@
+languageId: ruby
+command:
+  version: 1
+  spokenForm: change list
+  action: clearAndSetSelection
+  targets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: list, includeSiblings: false}
+initialState:
+  documentContents: "[\"hello\"]"
+  selections:
+    - anchor: {line: 0, character: 1}
+      active: {line: 0, character: 1}
+  marks: {}
+finalState:
+  documentContents: ""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: containingScope, scopeType: list, includeSiblings: false}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList4.yml
+++ b/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList4.yml
@@ -1,0 +1,23 @@
+languageId: ruby
+command:
+  version: 1
+  spokenForm: change list
+  action: clearAndSetSelection
+  targets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: list, includeSiblings: false}
+initialState:
+  documentContents: "[\"hello\"]"
+  selections:
+    - anchor: {line: 0, character: 8}
+      active: {line: 0, character: 8}
+  marks: {}
+finalState:
+  documentContents: ""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: containingScope, scopeType: list, includeSiblings: false}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList5.yml
+++ b/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList5.yml
@@ -1,0 +1,23 @@
+languageId: ruby
+command:
+  version: 1
+  spokenForm: change list
+  action: clearAndSetSelection
+  targets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: list, includeSiblings: false}
+initialState:
+  documentContents: "[\"hello\"]"
+  selections:
+    - anchor: {line: 0, character: 9}
+      active: {line: 0, character: 9}
+  marks: {}
+finalState:
+  documentContents: ""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: containingScope, scopeType: list, includeSiblings: false}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList6.yml
+++ b/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList6.yml
@@ -1,0 +1,23 @@
+languageId: ruby
+command:
+  version: 1
+  spokenForm: change list
+  action: clearAndSetSelection
+  targets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: list, includeSiblings: false}
+initialState:
+  documentContents: "[\"hello\"] "
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 7}
+  marks: {}
+finalState:
+  documentContents: " "
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: containingScope, scopeType: list, includeSiblings: false}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList7.yml
+++ b/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList7.yml
@@ -1,0 +1,23 @@
+languageId: ruby
+command:
+  version: 1
+  spokenForm: change list
+  action: clearAndSetSelection
+  targets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: list, includeSiblings: false}
+initialState:
+  documentContents: "[\"hello\"] "
+  selections:
+    - anchor: {line: 0, character: 6}
+      active: {line: 0, character: 6}
+  marks: {}
+finalState:
+  documentContents: " "
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: containingScope, scopeType: list, includeSiblings: false}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList8.yml
+++ b/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList8.yml
@@ -1,0 +1,23 @@
+languageId: ruby
+command:
+  version: 1
+  spokenForm: change list
+  action: clearAndSetSelection
+  targets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: list, includeSiblings: false}
+initialState:
+  documentContents: "[1,2,3, [4,5,6, [7, 8, 9]]]"
+  selections:
+    - anchor: {line: 0, character: 19}
+      active: {line: 0, character: 19}
+  marks: {}
+finalState:
+  documentContents: "[1,2,3, [4,5,6, ]]"
+  selections:
+    - anchor: {line: 0, character: 16}
+      active: {line: 0, character: 16}
+  thatMark:
+    - anchor: {line: 0, character: 16}
+      active: {line: 0, character: 16}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: containingScope, scopeType: list, includeSiblings: false}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList9.yml
+++ b/src/test/suite/fixtures/recorded/queryBasedMatchers/changeList9.yml
@@ -1,0 +1,23 @@
+languageId: ruby
+command:
+  version: 1
+  spokenForm: change list
+  action: clearAndSetSelection
+  targets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: list, includeSiblings: false}
+initialState:
+  documentContents: "[1, 2, 3, [4, 5, 6, [7, 8, 9]]]"
+  selections:
+    - anchor: {line: 0, character: 24}
+      active: {line: 0, character: 24}
+  marks: {}
+finalState:
+  documentContents: "[1, 2, 3, [4, 5, 6, ]]"
+  selections:
+    - anchor: {line: 0, character: 20}
+      active: {line: 0, character: 20}
+  thatMark:
+    - anchor: {line: 0, character: 20}
+      active: {line: 0, character: 20}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: containingScope, scopeType: list, includeSiblings: false}, isImplicit: false}]

--- a/src/test/suite/queryBasedSpecification.test.ts
+++ b/src/test/suite/queryBasedSpecification.test.ts
@@ -1,0 +1,3 @@
+suite("queryBasedSpecification", async function () {
+  test("generates the correct matchers", async () => {});
+});

--- a/src/test/suite/queryNodeMatchers.test.ts
+++ b/src/test/suite/queryNodeMatchers.test.ts
@@ -1,0 +1,165 @@
+import * as assert from "assert";
+import { openNewEditor } from "../openNewEditor";
+import { defaultMatcher } from "../../util/queryNodeMatchers";
+import { getParseTreeApi } from "../../util/getExtensionApi";
+import { selectionWithEditorFromPositions } from "../../util/selectionUtils";
+import { NodeMatcher, SelectionWithEditor } from "../../typings/Types";
+import { Tree } from "web-tree-sitter";
+import { Position } from "vscode";
+
+suite("queryNodeMatcher", async () => {
+  suite("happy path", async () => {
+    const matcher = defaultMatcher("comment", false, `(comment) @comment`);
+    const nodeType = "comment";
+
+    test("match single", async () => {
+      const code = "# hello world";
+
+      const { selection, tree } = await getNodeAndEditor(code);
+      assertMatch(matcher, tree, nodeType, selection, 1);
+    });
+
+    test("match multiple by parent", async () => {
+      const code = `# hello world
+variable_def = "yep"
+# hello world
+# hello world`;
+      const { selection, tree } = await getNodeAndEditor(code);
+      assertMatch(matcher, tree, nodeType, selection, 3, {
+        includeSiblings: true,
+      });
+    });
+  });
+
+  suite("expands range", async () => {
+    const matcher = defaultMatcher("comment", false, `(comment) @comment`);
+    const nodeType = "comment";
+    const cursorPositions = {
+      start: new Position(0, 0),
+      end: new Position(1, 2),
+    };
+
+    test("matches with selection across two node the same type", async () => {
+      const code = `# hello
+# world`;
+      const { selection, tree } = await getNodeAndEditor(code, cursorPositions);
+      const matches = assertMatch(matcher, tree, nodeType, selection, 1);
+      assert.equal(matches![0].selection.selection.isSingleLine, false);
+    });
+
+    test("no match with selection across two node the different type", async () => {
+      const code = `# hello
+hello_world()`;
+      const { selection, tree } = await getNodeAndEditor(code, cursorPositions);
+      assertMatch(matcher, tree, nodeType, selection, 0);
+    });
+  });
+
+  suite("non-matches due to positions", async () => {
+    const matcher = defaultMatcher(
+      "functionCall",
+      false,
+      `(call) @functionCall`
+    );
+
+    // Use a node type that does not take up the entire line following the it.
+    const code = " hello_world()       ";
+    const nonMatchPositions = [
+      {
+        start: new Position(0, 0),
+        end: new Position(0, 0),
+        message: "Empty selection before the scope",
+      },
+      {
+        start: new Position(0, code.length - 1),
+        end: new Position(0, code.length - 1),
+        message: "Empty selection after the scope",
+      },
+      {
+        start: new Position(0, 0),
+        end: new Position(0, 1),
+        message: "Non-empty selection before the scope",
+      },
+      {
+        start: new Position(0, 0),
+        end: new Position(0, 1),
+        message: "Non-empty selection abutting scope",
+      },
+      {
+        start: new Position(0, code.length - 2),
+        end: new Position(0, code.length - 1),
+        message: "Non-empty selection after the scope",
+      },
+      {
+        start: new Position(0, 0),
+        end: new Position(0, 5),
+        message: "Non-empty selection starting before and ending within scope",
+      },
+      {
+        start: new Position(0, 5),
+        end: new Position(0, code.length - 1),
+        message:
+          "Non-empty selection starting within scope and ending outside of scope",
+      },
+    ];
+    for (const position of nonMatchPositions) {
+      test(`empty selection in whitespace before scope does not match: ${position.message}`, async () => {
+        const nodeType = "comment";
+        const { selection, tree } = await getNodeAndEditor(code, position);
+        assertMatch(matcher, tree, nodeType, selection, 0);
+      });
+    }
+  });
+
+  test("match multiple by searchScope throws error", async () => {
+    const code = "# hello world";
+    const matcher = defaultMatcher("comment", true, `(comment) @comment`);
+    const { selection, tree } = await getNodeAndEditor(code);
+    assert.throws(() => {
+      matcher(selection, tree, true);
+    });
+  });
+});
+
+const getNodeAndEditor = async (
+  code: string,
+  cursorPositions: { start: Position; end: Position } = {
+    start: new Position(0, 0),
+    end: new Position(0, 0),
+  }
+): Promise<{ selection: SelectionWithEditor; tree: Tree }> => {
+  const editor = await openNewEditor(code, "ruby");
+  const { getTree } = await getParseTreeApi();
+  const tree = getTree(editor.document);
+
+  const selectionWithEditor = selectionWithEditorFromPositions(
+    { selection: editor.selection, editor },
+    cursorPositions.start,
+    cursorPositions.end
+  );
+
+  return {
+    selection: selectionWithEditor,
+    tree: tree,
+  };
+};
+
+const assertMatch = (
+  matcher: NodeMatcher,
+  tree: Tree,
+  nodeType: string,
+  selectionWithEditor: SelectionWithEditor,
+  expectedMatches: number,
+  options: { includeSiblings?: boolean } = { includeSiblings: false }
+) => {
+  const matches = matcher(selectionWithEditor, tree, options?.includeSiblings);
+  if (expectedMatches === 0) {
+    assert.equal(matches, null);
+  } else {
+    assert.equal(expectedMatches, matches!.length);
+    for (const match of matches!) {
+      assert.equal(nodeType, match.node.type);
+    }
+  }
+  return matches;
+};

--- a/src/typings/Types.ts
+++ b/src/typings/Types.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { ExtensionContext, Location } from "vscode";
-import { SyntaxNode } from "web-tree-sitter";
+import { SyntaxNode, Tree } from "web-tree-sitter";
 import { ActionRecord } from "../actions/actions.types";
 import Debug from "../core/Debug";
 import Decorations from "../core/Decorations";
@@ -31,6 +31,7 @@ export interface ProcessedTargetsContext {
   thatMark: SelectionWithEditor[];
   sourceMark: SelectionWithEditor[];
   getNodeAtLocation: (location: Location) => SyntaxNode;
+  getTree: (document: vscode.TextDocument) => Tree;
 }
 
 export interface SelectionWithEditor {
@@ -127,6 +128,11 @@ export interface Graph {
   readonly getNodeAtLocation: (location: vscode.Location) => SyntaxNode;
 
   /**
+   * Function to access the tree sitter tree.
+   */
+  readonly getTree: (document: vscode.TextDocument) => Tree;
+
+  /**
    * Debug logger
    */
   readonly debug: Debug;
@@ -146,7 +152,8 @@ export type NodeMatcherAlternative = NodeMatcher | string[] | string;
 
 export type NodeMatcher = (
   selection: SelectionWithEditor,
-  node: SyntaxNode
+  treeSitterHook: SyntaxNode | Tree,
+  siblings?: boolean
 ) => NodeMatcherValue[] | null;
 
 /**

--- a/src/typings/targetDescriptor.types.ts
+++ b/src/typings/targetDescriptor.types.ts
@@ -65,50 +65,54 @@ export type SurroundingPairName =
   | SimpleSurroundingPairName
   | ComplexSurroundingPairName;
 
-export type SimpleScopeTypeType =
-  | "argumentOrParameter"
-  | "anonymousFunction"
-  | "attribute"
-  | "class"
-  | "className"
-  | "collectionItem"
-  | "collectionKey"
-  | "comment"
-  | "functionCall"
-  | "functionName"
-  | "ifStatement"
-  | "list"
-  | "map"
-  | "name"
-  | "namedFunction"
-  | "regularExpression"
-  | "statement"
-  | "string"
-  | "type"
-  | "value"
-  | "condition"
-  | "section"
-  | "sectionLevelOne"
-  | "sectionLevelTwo"
-  | "sectionLevelThree"
-  | "sectionLevelFour"
-  | "sectionLevelFive"
-  | "sectionLevelSix"
-  | "selector"
-  | "xmlBothTags"
-  | "xmlElement"
-  | "xmlEndTag"
-  | "xmlStartTag"
-  // Text based scopes
-  | "token"
-  | "line"
-  | "notebookCell"
-  | "paragraph"
-  | "document"
-  | "character"
-  | "word"
-  | "nonWhitespaceSequence"
-  | "url";
+// TODO: Move to constants file;
+export const simpleScopeTypeTypes = [
+  "argumentOrParameter",
+  "anonymousFunction",
+  "attribute",
+  "class",
+  "className",
+  "collectionItem",
+  "collectionKey",
+  "comment",
+  "functionCall",
+  "functionName",
+  "ifStatement",
+  "list",
+  "map",
+  "name",
+  "namedFunction",
+  "regularExpression",
+  "statement",
+  "string",
+  "type",
+  "value",
+  "condition",
+  "section",
+  "sectionLevelOne",
+  "sectionLevelTwo",
+  "sectionLevelThree",
+  "sectionLevelFour",
+  "sectionLevelFive",
+  "sectionLevelSix",
+  "selector",
+  "xmlBothTags",
+  "xmlElement",
+  "xmlEndTag",
+  "xmlStartTag",
+  // Text based scopes,
+  "token",
+  "line",
+  "notebookCell",
+  "paragraph",
+  "document",
+  "character",
+  "word",
+  "nonWhitespaceSequence",
+  "url",
+];
+
+export type SimpleScopeTypeType = typeof simpleScopeTypeTypes[number];
 
 export interface SimpleScopeType {
   type: SimpleScopeTypeType;

--- a/src/typings/treeSitter.ts
+++ b/src/typings/treeSitter.ts
@@ -158,7 +158,7 @@ declare module "web-tree-sitter" {
       query(source: string): Query;
     }
 
-    interface QueryCapture {
+    export interface QueryCapture {
       name: string;
       node: SyntaxNode;
     }
@@ -188,6 +188,7 @@ declare module "web-tree-sitter" {
         endPosition?: Point
       ): QueryCapture[];
       predicatesForPattern(patternIndex: number): PredicateResult[];
+      predicates: PredicateResult;
     }
   }
 

--- a/src/util/getExtensionApi.ts
+++ b/src/util/getExtensionApi.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { ThatMark } from "../core/ThatMark";
-import { SyntaxNode } from "web-tree-sitter";
+import { SyntaxNode, Tree } from "web-tree-sitter";
 import { Graph } from "../typings/Types";
 
 export interface CursorlessApi {
@@ -15,6 +15,7 @@ export interface CursorlessApi {
 
 export interface ParseTreeApi {
   getNodeAtLocation(location: vscode.Location): SyntaxNode;
+  getTree(document: vscode.TextDocument): Tree;
   loadLanguage: (languageId: string) => Promise<boolean>;
 }
 

--- a/src/util/nodeMatchers.ts
+++ b/src/util/nodeMatchers.ts
@@ -1,4 +1,4 @@
-import { SyntaxNode } from "web-tree-sitter";
+import { SyntaxNode, Tree } from "web-tree-sitter";
 import {
   NodeMatcher,
   NodeFinder,
@@ -26,7 +26,11 @@ export function matcher(
   finder: NodeFinder,
   selector: SelectionExtractor = simpleSelectionExtractor
 ): NodeMatcher {
-  return function (selection: SelectionWithEditor, node: SyntaxNode) {
+  return function (
+    selection: SelectionWithEditor,
+    treeSitterHook: SyntaxNode | Tree
+  ) {
+    const node = treeSitterHook as SyntaxNode;
     const targetNode = finder(node, selection.selection);
     return targetNode != null
       ? [
@@ -53,7 +57,11 @@ export function chainedMatcher(
 ): NodeMatcher {
   const nodeFinder = chainedNodeFinder(...finders);
 
-  return function (selection: SelectionWithEditor, initialNode: SyntaxNode) {
+  return function (
+    selection: SelectionWithEditor,
+    treeSitterHook: SyntaxNode | Tree
+  ) {
+    const initialNode = treeSitterHook as SyntaxNode;
     const returnNode = nodeFinder(initialNode);
 
     if (returnNode == null) {
@@ -156,7 +164,11 @@ export function trailingMatcher(
  * @returns A NodeMatcher that tries the given matchers in sequence
  */
 export function cascadingMatcher(...matchers: NodeMatcher[]): NodeMatcher {
-  return (selection: SelectionWithEditor, node: SyntaxNode) => {
+  return (
+    selection: SelectionWithEditor,
+    treeSitterHook: SyntaxNode | Tree
+  ) => {
+    const node = treeSitterHook as SyntaxNode;
     for (const matcher of matchers) {
       const match = matcher(selection, node);
       if (match != null) {
@@ -170,7 +182,7 @@ export function cascadingMatcher(...matchers: NodeMatcher[]): NodeMatcher {
 
 export const notSupported: NodeMatcher = (
   _selection: SelectionWithEditor,
-  _node: SyntaxNode
+  _node: SyntaxNode | Tree
 ) => {
   throw new Error("Node type not supported");
 };

--- a/src/util/queryNodeMatchers.ts
+++ b/src/util/queryNodeMatchers.ts
@@ -1,0 +1,275 @@
+import { Position, Range, Selection } from "vscode";
+import { SyntaxNode, Query, QueryCapture, Point, Tree } from "web-tree-sitter";
+import {
+  NodeMatcher,
+  NodeMatcherValue,
+  SelectionExtractor,
+  SelectionWithEditor,
+} from "../typings/Types";
+import {
+  makeRangeFromPositions,
+  simpleSelectionExtractor,
+} from "./nodeSelectors";
+
+let query: Query;
+
+/**
+ *
+ * @param scopeType The scopeType the matcher is responsible for matching.
+ * @param isIterationScopePresent Indicates whether iteration scope will be defined via the scm file or derived
+ * by looking at the parent.
+ * @param scopeQuery The query with node matchers for a specific language.
+ * @param selector Unused, discard once legacy matching is removed.
+ * @returns A {@link NodeMatcher} object that can be used to for a specific scopeType.
+ */
+export function defaultMatcher(
+  scopeType: string,
+  isIterationScopePresent: boolean,
+  scopeQuery: string,
+  selector: SelectionExtractor = simpleSelectionExtractor
+): NodeMatcher {
+  return (
+    selection: SelectionWithEditor,
+    treeSitterHook: Tree | SyntaxNode,
+    siblings: boolean = false
+  ): NodeMatcherValue[] | null => {
+    const tree = treeSitterHook as Tree;
+    const query = getQuery(tree, scopeQuery);
+    const rawCaptures = getCapture(selection, tree.rootNode, query, scopeType);
+
+    if (!rawCaptures || rawCaptures.length === 0) {
+      return null;
+    }
+    let selectedCaptures = selectCaptureByRange(rawCaptures, selection);
+
+    if (!selectedCaptures) {
+      return null;
+    }
+
+    if (siblings) {
+      return generateCapturesIfSiblingsPresent(
+        selectedCaptures,
+        isIterationScopePresent,
+        query,
+        scopeType,
+        selector,
+        selection
+      );
+    }
+
+    const leadingNode = selectedCaptures[0].node;
+    // TODO: Could we target ES2022 and use .at(-1)?
+    const trailingNode = selectedCaptures[selectedCaptures.length - 1].node;
+    return [
+      {
+        // TODO: What should we do here if we are matching multiple nodes for the selection? Which node do we reference?
+        node: selectedCaptures[0].node,
+        selection: {
+          selection: new Selection(
+            new Position(
+              leadingNode.startPosition.row,
+              leadingNode.startPosition.column
+            ),
+            new Position(
+              trailingNode.endPosition.row,
+              trailingNode.endPosition.column
+            )
+          ),
+          context: {},
+        },
+      },
+    ];
+  };
+}
+
+function generateCapturesIfSiblingsPresent(
+  selectedCaptures: QueryCapture[],
+  isIterationScopePresent: boolean,
+  query: Query,
+  scopeType: string,
+  selector: SelectionExtractor,
+  selection: SelectionWithEditor
+) {
+  if (selectedCaptures.length > 1) {
+    throw new Error(
+      "Cannot match siblings on captures which return a range. Try selecitng a single node."
+    );
+  } else if (isIterationScopePresent) {
+    throw new Error("searchScope based queries are not implemented.");
+  }
+
+  let siblingCaptures = findBySiblingsByParent(
+    selectedCaptures[0].node,
+    query,
+    scopeType
+  );
+
+  return siblingCaptures!.map((c) => {
+    return {
+      node: c.node,
+      selection: selector(selection.editor, c.node),
+    };
+  });
+}
+
+/**
+ * Accesses the memoized compiled query.
+ * @param node Used only to return the tree's language.
+ * @param scopeQuery The scm query file for a given language.
+ * @returns Query object
+ */
+function getQuery(tree: Tree, scopeQuery: string): Query {
+  if (!query) {
+    query = tree.getLanguage().query(scopeQuery);
+  }
+  return query;
+}
+
+/**
+ * Prioritize current position of the cursor, one space to the right and then finally one space to the left.
+ * @param selection Used to derive start and end points for a selection.
+ * @param root Query is run against the root node.
+ * @param query Compiled query to run against the parsed tree.
+ * @param scopeType The scope type that the matcher is responsible for matching.
+ * @returns Captures that match the scope type, possibly an empty list if there are no matches.
+ */
+function getCapture(
+  selection: SelectionWithEditor,
+  root: SyntaxNode,
+  query: Query,
+  scopeType: string
+) {
+  const startPoint = generatePointFromSelection(selection, "start");
+  const endPoint = generatePointFromSelection(selection, "end");
+
+  const positions = [
+    { startPoint, endPoint },
+    {
+      startPoint,
+      endPoint: { row: endPoint.row, column: endPoint.column + 1 },
+    },
+    {
+      startPoint: { row: startPoint.row, column: startPoint.column - 1 },
+      endPoint,
+    },
+  ];
+
+  for (const { startPoint, endPoint } of positions) {
+    const captures = query
+      .captures(root, startPoint, endPoint)
+      .filter((capture) => {
+        return capture.name === scopeType;
+      });
+    if (captures && captures.length > 0) {
+      return captures;
+    }
+  }
+}
+
+/**
+ * This method takes captures for a given range and scopeType, alongside a selection and then returns
+ * the relevant captures. If the selection is a single point, only return one capture. If the selection is a
+ * range, return a leading and trailing capture. If there is no leading capture, bail early.
+ *
+ * @param captures The matching nodes for a given scopeType and range.
+ * @param selection Used to derive start and end points which are matched against a capture.
+ * @returns The capture for a single point or the captures for a start and end point.
+ */
+function selectCaptureByRange(
+  captures: QueryCapture[],
+  selection: SelectionWithEditor
+): QueryCapture[] | null {
+  let isSinglePoint = selection.selection.isEmpty;
+
+  let leadingCapture = matchCapturesOnPosition(
+    captures,
+    selection.selection.start
+  );
+
+  if (!leadingCapture) {
+    return null;
+  }
+
+  if (isSinglePoint) {
+    return [leadingCapture];
+  } else {
+    const trailingCapture = matchCapturesOnPosition(
+      captures,
+      selection.selection.end
+    );
+    if (!trailingCapture) {
+      return null;
+    }
+    return [leadingCapture, trailingCapture];
+  }
+}
+
+/**
+ *
+ * @param captures The matching nodes for a given scopeType and range.
+ * @param position The position to match against.
+ * @returns The capture furthest down the tree which contains the position.
+ */
+function matchCapturesOnPosition(captures: QueryCapture[], position: Position) {
+  let capture;
+  for (const c of captures) {
+    const captureRange: Range = makeRangeFromPositions(
+      c.node.startPosition,
+      c.node.endPosition
+    );
+    if (captureRange.contains(position)) {
+      if (!capture) {
+        capture = c;
+      } else {
+        const leadingCaptureRange = makeRangeFromPositions(
+          capture.node.startPosition,
+          capture.node.endPosition
+        );
+        if (leadingCaptureRange.contains(captureRange)) {
+          capture = c;
+        }
+      }
+    }
+  }
+  return capture;
+}
+
+function generatePointFromSelection(
+  selection: SelectionWithEditor,
+  pointType: "start" | "end"
+): Point {
+  return {
+    row: selection.selection[pointType].line,
+    column: selection.selection[pointType].character,
+  };
+}
+
+/**
+ * Ported from legacy parent matching. This code is responsible for finding siblings of nodes which do not have
+ * a `searchScope` defined in the language's .scm query file.
+ * @param node The matching node from the query and range matching. We will look at this node's parent to find siblings.
+ * @param query The compiled query which will be run against the parent node.
+ * @param scopeType The scope type that the matcher is responsible for matching.
+ * @returns Sibling matches of the node or only the node itself.
+ */
+function findBySiblingsByParent(
+  node: SyntaxNode,
+  query: Query,
+  scopeType: string
+) {
+  let parent: SyntaxNode | null = node.parent;
+  const ids = parent?.namedChildren.map((c) => c.id);
+  while (parent != null) {
+    const matches = query
+      .captures(parent)
+      .filter(
+        (capture) =>
+          capture.name === scopeType && ids?.includes(capture.node.id)
+      );
+    if (matches.length > 0) {
+      return matches;
+    }
+    parent = parent.parent;
+  }
+  return [];
+}

--- a/src/util/selectionUtils.ts
+++ b/src/util/selectionUtils.ts
@@ -16,7 +16,7 @@ export function selectionWithEditorFromRange(
   return selectionWithEditorFromPositions(selection, range.start, range.end);
 }
 
-function selectionWithEditorFromPositions(
+export function selectionWithEditorFromPositions(
   selection: SelectionWithEditor,
   start: Position,
   end: Position

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,7 +36,7 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
   integrity sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==
   dependencies:
-    "@nodelib/fs.stat" "2.0.5"
+    "@nodelib/fs.stat" "2.0.4"
     run-parallel "^1.1.9"
 
 "@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
@@ -49,7 +49,7 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
   integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
   dependencies:
-    "@nodelib/fs.scandir" "2.1.5"
+    "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
 "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.3":
@@ -1025,7 +1025,14 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz"
+  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
+
+is-glob@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==


### PR DESCRIPTION
Fix gabled imports in [ContainingSyntaxScopeStage.ts](src/processTargets/modifiers/scopeTypeStages/ContainingSyntaxScopeStage.ts) and misdirected imports in [getNodeMatcher.ts](src/languages/getNodeMatcher.ts), [html.ts](src/languages/html.ts), and [queryBasedSpecification.ts](src/languages/queryBasedSpecification.ts).